### PR TITLE
feat: support AGP namespace property

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.example.system_info_plus'
+    }
     compileSdkVersion 30
 
     compileOptions {


### PR DESCRIPTION
## Overview

Add a `namespace` property setting for Android Gradle Plugin (AGP).

## Context

Starting with AGP 8.0, the `namespace` property is required in the module-level build script. [^1]
To maintain compatibility with versions below AGP 7.3, add an if statement to check for the presence of the property.

[^1]: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl

## Copilot Summary

<details><summary>Details</summary>
<p>

This pull request includes a change to the `android/build.gradle` file. The change involves adding a conditional statement to check if the `android` project has a property called `namespace`. If the property exists, it sets the namespace to 'com.example.system_info_plus'. This helps in providing a unique identifier for the Android project.

* [`android/build.gradle`](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aR25-R27): Added a conditional statement to set the namespace of the project if the `namespace` property exists.

</p>
</details> 